### PR TITLE
update docs to not use sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ This repository contains a tiny Dockerfile to be able to test changes to the kaf
 To run the docker container, use something like the following (assumes that kafka-site repository is in `../kafka-site`).
 
 ```
-sudo docker build -t kafka-site:v1 .
-sudo docker run -it -v $(pwd)/../kafka-site:/usr/local/apache2/htdocs/ -p 80:80 kafka-site:v1
+docker build -t kafka-site:v1 .
+docker run -it -v $(pwd)/../kafka-site:/usr/local/apache2/htdocs/ -p 8080:80 kafka-site:v1
 ```
 
-Then, the site should render at `localhost:80`.
+Then, the site should render at [http://localhost:8080](http://localhost:8080).
 


### PR DESCRIPTION
Thanks for making this, very useful!

Quick docs fix get rid of `sudo`